### PR TITLE
Shift CogComp Maven repo to new location

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,14 +134,14 @@
         <pluginRepository>
             <id>CogcompSoftware</id>
             <name>CogcompSoftware</name>
-            <url>http://cogcomp.cs.illinois.edu/m2repo/</url>
+            <url>http://cogcomp.org/m2repo/</url>
         </pluginRepository>
     </pluginRepositories>
     <repositories>
         <repository>
             <id>CogcompSoftware</id>
             <name>CogcompSoftware</name>
-            <url>http://cogcomp.cs.illinois.edu/m2repo/</url>
+            <url>http://cogcomp.org/m2repo/</url>
         </repository>
         <repository>
             <id>StanfordNLP</id>


### PR DESCRIPTION
It looks like the Maven repo formerly at Illinois is now at cogcomp.org. This update allows many of the dependencies to be properly resolved.